### PR TITLE
Bugfix/line 88

### DIFF
--- a/Consul/Client.php
+++ b/Consul/Client.php
@@ -81,11 +81,12 @@ class Client
         $this->logger->debug(sprintf("Response:\n%s\n%s\n%s", $response->getStatusCode(), json_encode($response->getHeaders()), $response->getBody()->getContents()));
 
         if (400 <= $response->getStatusCode()) {
-            $message = sprintf('Something went wrong when calling consul (%s - %s).', $response->getStatusCode(), $response->getReasonPhrase());
+            $message = sprintf('Something went wrong when calling consul statusCode=[%s] reasonPhrase=[%s] uri=[%s]).', $response->getStatusCode(), $response->getReasonPhrase(), $request->getUri());
 
             $this->logger->error($message);
 
-            $message .= "\n$response";
+
+            $message .= "\n" . $response->getBody()->__toString();
             if (500 <= $response->getStatusCode()) {
                 throw new ServerException($message);
             }

--- a/Consul/Client.php
+++ b/Consul/Client.php
@@ -66,7 +66,7 @@ class Client
     public function send(RequestInterface $request)
     {
         $this->logger->info(sprintf('%s "%s"', $request->getMethod(), $request->getUri()));
-        $this->logger->debug(sprintf("Request:\n%s", (string) $request));
+        $this->logger->debug(sprintf("Request:\n%s\n%s\n%s", $request->getUri(), $request->getMethod(), json_encode($request->getHeaders())));
 
         try {
             $response = $this->client->send($request);
@@ -78,7 +78,7 @@ class Client
             throw new ServerException($message);
         }
 
-        $this->logger->debug(sprintf("Response:\n%s", $response));
+        $this->logger->debug(sprintf("Response:\n%s\n%s\n%s", $response->getStatusCode(), json_encode($response->getHeaders()), $response->getBody()->getContents()));
 
         if (400 <= $response->getStatusCode()) {
             $message = sprintf('Something went wrong when calling consul (%s - %s).', $response->getStatusCode(), $response->getReasonPhrase());

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.2-dev"
+            "dev-master": "1.2.1-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "XerxesDGreat/consul-php-sdk",
+    "name": "life360/consul-php-sdk",
     "description": "SDK to talk with consul.io API. Forked from sensiolabs/consul-php-sdk to provide Guzzle 6.0 compatibility",
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,11 @@
 {
-    "name": "sensiolabs/consul-php-sdk",
-    "description": "SDK to talk with consul.io API",
+    "name": "XerxesDGreat/consul-php-sdk",
+    "description": "SDK to talk with consul.io API. Forked from sensiolabs/consul-php-sdk to provide Guzzle 6.0 compatibility",
     "license": "MIT",
     "authors": [
         {
-            "name": "Grégoire Pineau",
-            "email": "lyrixx@lyrixx.info"
+            "name": "Josh Wickham",
+            "email": "josh@i-josh.com"
         }
     ],
     "require": {
@@ -19,7 +19,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.1-dev"
+            "dev-master": "1.2-dev"
         }
     }
 }


### PR DESCRIPTION
Fix a warning and add more explicit logging

The error being fixed is ```{"level":4,"code":4096,"error":"Warning","description":"Object of class GuzzleHttp\\Psr7\\Response could not be converted to string","file":"\/mnt\/hgfs\/platform\/vendor\/life360\/consul-php-sdk\/Consul\/Client.php","line":88,"context":{"request":{},"response":{},"message":"Something went wrong when calling consul (404 - Not Found)."},"start":2,"path":"ROOT\/vendor\/life360\/consul-php-sdk\/Consul\/Client.php"}```

The logging change is to add the consul uri when a warning of this kind comes up so we can see which key is being queried.