### PR TITLE
Bugfix for PSR Stream behaviour

### DIFF
--- a/Consul/Client.php
+++ b/Consul/Client.php
@@ -92,7 +92,7 @@ class Client
         }
 
 
-        return new ConsulResponse($response->getHeaders(), $response->getBody()->getContents());
+        return new ConsulResponse($response->getHeaders(), (string)$response->getBody());
     }
 
     private function formatResponse(Response $response)

--- a/Consul/Client.php
+++ b/Consul/Client.php
@@ -4,7 +4,7 @@ namespace SensioLabs\Consul;
 
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\TransferException;
-use GuzzleHttp\Message\RequestInterface;
+use GuzzleHttp\Psr7\Response;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use SensioLabs\Consul\Exception\ClientException;
@@ -19,55 +19,55 @@ class Client
     {
         $options = array_replace(array(
             'base_url' => 'http://127.0.0.1:8500',
+            'http_errors' => false,
         ), $options);
 
         $this->client = $client ?: new GuzzleClient($options);
-        $this->client->setDefaultOption('exceptions', false);
         $this->logger = $logger ?: new NullLogger();
     }
 
     public function get($url = null, array $options = array())
     {
-        return $this->send($this->client->createRequest('GET', $url, $options));
+        return $this->doRequest('GET', $url, $options);
     }
 
     public function head($url, array $options = array())
     {
-        return $this->send($this->client->createRequest('HEAD', $url, $options));
+        return $this->doRequest('HEAD', $url, $options);
     }
 
     public function delete($url, array $options = array())
     {
-        return $this->send($this->client->createRequest('DELETE', $url, $options));
+        return $this->doRequest('DELETE', $url, $options);
     }
 
     public function put($url, array $options = array())
     {
-        return $this->send($this->client->createRequest('PUT', $url, $options));
+        return $this->doRequest('PUT', $url, $options);
     }
 
     public function patch($url, array $options = array())
     {
-        return $this->send($this->client->createRequest('PATCH', $url, $options));
+        return $this->doRequest('PATCH', $url, $options);
     }
 
     public function post($url, array $options = array())
     {
-        return $this->send($this->client->createRequest('POST', $url, $options));
+        return $this->doRequest('POST', $url, $options);
     }
 
     public function options($url, array $options = array())
     {
-        return $this->send($this->client->createRequest('OPTIONS', $url, $options));
+        return $this->doRequest('OPTIONS', $url, $options);
     }
 
-    public function send(RequestInterface $request)
+    private function doRequest($method, $url, $options)
     {
-        $this->logger->info(sprintf('%s "%s"', $request->getMethod(), $request->getUrl()));
-        $this->logger->debug(sprintf("Request:\n%s", (string) $request));
+        $this->logger->info(sprintf('%s "%s"', $method, $url));
+        $this->logger->debug(sprintf("Requesting %s %s", $method, $url), array('options' => $options));
 
         try {
-            $response = $this->client->send($request);
+            $response = $this->client->request($method, $url, $options);
         } catch (TransferException $e) {
             $message = sprintf('Something went wrong when calling consul (%s).', $e->getMessage());
 
@@ -76,7 +76,7 @@ class Client
             throw new ServerException($message);
         }
 
-        $this->logger->debug(sprintf("Response:\n%s", $response));
+        $this->logger->debug(sprintf("Response:\n%s", $this->formatResponse($response)));
 
         if (400 <= $response->getStatusCode()) {
             $message = sprintf('Something went wrong when calling consul (%s - %s).', $response->getStatusCode(), $response->getReasonPhrase());
@@ -91,6 +91,20 @@ class Client
             throw new ClientException($message);
         }
 
-        return $response;
+
+        return new ConsulResponse($response->getHeaders(), $response->getBody()->getContents());
+    }
+
+    private function formatResponse(Response $response)
+    {
+        $headers = array();
+
+        foreach ($response->getHeaders() as $key => $values) {
+            foreach ($values as $value) {
+                $headers[] = sprintf('%s: %s', $key, $value);
+            }
+        }
+
+        return sprintf("%s\n\n%s", implode("\n", $headers), $response->getBody());
     }
 }

--- a/Consul/ConsulResponse.php
+++ b/Consul/ConsulResponse.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SensioLabs\Consul;
+
+class ConsulResponse
+{
+    private $headers;
+    private $body;
+
+    public function __construct($headers, $body)
+    {
+        $this->headers = $headers;
+        $this->body = $body;
+    }
+
+    public function getHeaders()
+    {
+        return $this->headers;
+    }
+
+    public function getBody()
+    {
+        return $this->body;
+    }
+
+    public function json()
+    {
+        return json_decode($this->body, true);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 Consul SDK
 ==========
 
+Compatibility
+-------------
+
+This table shows this SDK compatibility regarding Guzzle version:
+
+| SDK Version | Guzzle Version
+| ----------- | --------------
+| 1.x         | >=4, <6
+| 2.x         | 6
+
 Installation
 ------------
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle": ">=4,<6",
+        "guzzlehttp/guzzle": "^6.0",
         "psr/log": "~1.0"
     },
     "autoload": {
@@ -19,7 +19,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.1-dev"
+            "dev-master": "2.0-dev"
         }
     }
 }


### PR DESCRIPTION
This contains commits in #19 

getContents gets the contents of the body from the current position in the response stream to the end. The call to formatResponse (and subsequent casting to string in that function) moves the position in the stream to the end.

The behaviour of __toString on StreamInterface dictates seeking to the beginning of the stream before reading, and this solves the problem.
