### PR TITLE
Guzzle6 fixes

### DIFF
--- a/Consul/Client.php
+++ b/Consul/Client.php
@@ -87,7 +87,7 @@ class Client
 
             $this->logger->error($message);
 
-            $message .= "\n$response";
+            $message .= "\n" . (string)$response->getBody();
             if (500 <= $response->getStatusCode()) {
                 throw new ServerException($message);
             }

--- a/Consul/Client.php
+++ b/Consul/Client.php
@@ -18,7 +18,7 @@ class Client
     public function __construct(array $options = array(), LoggerInterface $logger = null, GuzzleClient $client = null)
     {
         $options = array_replace(array(
-            'base_url' => 'http://127.0.0.1:8500',
+            'base_uri' => 'http://127.0.0.1:8500',
             'http_errors' => false,
         ), $options);
 

--- a/Consul/Client.php
+++ b/Consul/Client.php
@@ -95,8 +95,7 @@ class Client
             throw new ClientException($message);
         }
 
-
-        return new ConsulResponse($response->getHeaders(), $response->getBody()->getContents());
+        return new ConsulResponse($response->getHeaders(), (string)$response->getBody());
     }
 
     private function formatResponse(Response $response)

--- a/Consul/Client.php
+++ b/Consul/Client.php
@@ -63,6 +63,10 @@ class Client
 
     private function doRequest($method, $url, $options)
     {
+        if (isset($options['body']) && is_array($options['body'])) {
+            $options['body'] = json_encode($options['body']);
+        }
+
         $this->logger->info(sprintf('%s "%s"', $method, $url));
         $this->logger->debug(sprintf("Requesting %s %s", $method, $url), array('options' => $options));
 


### PR DESCRIPTION
Guzzle6 uses `base_uri` and not `base_url` for default configuration
Guzzle6 expect the body to be pre-encoded as json before shipping 
Guzzle6 will return `''` on multiple reads on the same response unless you `->seek(0)` before next read - casting to string will do the seek and return the full response instead