### PR TITLE
Add http status code on exceptions

### DIFF
--- a/Consul/Client.php
+++ b/Consul/Client.php
@@ -89,10 +89,10 @@ class Client
 
             $message .= "\n" . (string)$response->getBody();
             if (500 <= $response->getStatusCode()) {
-                throw new ServerException($message);
+                throw new ServerException($message, $response->getStatusCode());
             }
 
-            throw new ClientException($message);
+            throw new ClientException($message, $response->getStatusCode());
         }
 
         return new ConsulResponse($response->getHeaders(), (string)$response->getBody());


### PR DESCRIPTION
This changeset makes the HTTP status code available on the exception message. Right now there is no way to distinguish between different HTTP errors that could happen except for a string match on exception message, it results in code like

```php
if (stristr($exception->getMessage(), '404 - Not Found')) {
   //... Logic here
}
```

which is not really scalable. After this change will be possible to write code like

```php
if ($exception->getCode() == 400) {
   //... Logic here
}
```