### PR TITLE
Make status code available on consul response

### DIFF
--- a/Consul/Client.php
+++ b/Consul/Client.php
@@ -95,7 +95,7 @@ class Client
             throw new ClientException($message, $response->getStatusCode());
         }
 
-        return new ConsulResponse($response->getHeaders(), (string)$response->getBody());
+        return new ConsulResponse($response->getHeaders(), (string)$response->getBody(), $response->getStatusCode());
     }
 
     private function formatResponse(Response $response)

--- a/Consul/ConsulResponse.php
+++ b/Consul/ConsulResponse.php
@@ -6,11 +6,13 @@ class ConsulResponse
 {
     private $headers;
     private $body;
+    private $status;
 
-    public function __construct($headers, $body)
+    public function __construct($headers, $body, $status = 200)
     {
         $this->headers = $headers;
         $this->body = $body;
+        $this->status = $status;
     }
 
     public function getHeaders()
@@ -21,6 +23,11 @@ class ConsulResponse
     public function getBody()
     {
         return $this->body;
+    }
+
+    public function getStatusCode()
+    {
+        return $this->status;
     }
 
     public function json()


### PR DESCRIPTION
Since this is a library for HTTP API, status code is crucial to maintain compatibility with specifications like PSR7 and other abstractions. This changeset makes status code available on consul response.
