### PR TITLE
Add blocking locks to the LockHandler helper

### DIFF
--- a/Consul/Helper/LockHandler.php
+++ b/Consul/Helper/LockHandler.php
@@ -2,49 +2,230 @@
 
 namespace SensioLabs\Consul\Helper;
 
+use SensioLabs\Consul\Exception\ClientException;
 use SensioLabs\Consul\Services\KV;
 use SensioLabs\Consul\Services\Session;
 
 class LockHandler
 {
+    /** @var  string */
     private $key;
+    /** @var string */
     private $value;
-    private $session;
-    private $kv;
+    /** @var Session */
+    private $sessionService;
+    /** @var KV */
+    private $kvService;
 
+    /** @var string */
     private $sessionId;
 
+    /** @var  bool */
+    private $lockAcquired = false;
+
+    /** @var bool */
+    private $shutdownRegistered = false;
+
+    /** @var string */
+    private $sessionTTL = '0s';
+
+    /** @var string */
+    private $lockDelay = '15s';
+
+    /** @var bool */
+    private $ephemeral = true;
+
+    /**
+     * LockHandler provides a convienient way to acquire advisory distributed locks using Consul. Once a lock is
+     * obtained only the session held by this particular LockHandler will be able to update the locked key, other
+     * LockHandlers will be denied/blocked. The LockHandler Helper must be used to ensure locking works. Updates to keys
+     * via the KV service will ignore the advisory lock.
+     *
+     * Optionally the LockHander will block for up to 10 minutes at while waiting for a lock to be released.
+     *
+     *
+     * @param string $key
+     * @param string $value
+     * @param Session|null $session
+     * @param KV|null $kv
+     */
     public function __construct($key, $value = null, Session $session = null, KV $kv = null)
     {
         $this->key = $key;
         $this->value = $value;
-        $this->session = $session ?: new Session();
-        $this->kv = $kv ?: new KV();
+        $this->sessionService = $session ?: new Session();
+        $this->kvService = $kv ?: new KV();
     }
 
-    public function lock()
+    /**
+     * Perform the actual lock. This can be called multiple times. If the lock is already acquired the lock will be
+     * retained and the value will be updated to the current value. If the lock is not yet acquired another attempt to
+     * acquire will be made. Specifying the $wait argument will cause the acquisition to block as described in
+     * "Blocking Queries" in https://www.consul.io/docs/agent/http.html This value must be specified in seconds.
+     *
+     * The wait will round up during blocking, so there is a chance that it will take slightly longer than the
+     * specified number of seconds to return.
+     *
+     * @param float $wait in seconds
+     * @return bool
+     */
+    public function lock($wait = 0.0)
     {
-        // Start a session
-        $session = $this->session->create()->json();
-        $this->sessionId = $session['ID'];
-
-        // Lock a key / value with the current session
-        $lockAcquired = $this->kv->put($this->key, (string) $this->value, ['acquire' => $this->sessionId])->json();
-
-        if (false === $lockAcquired) {
-            $this->session->destroy($this->sessionId);
-
-            return false;
+        $end_time = microtime(true) + $wait;
+        $modifyIndex = 0;
+        // If we are going to block while waiting for the lock
+        if ($wait > 0.0) {
+            // This is when we should stop trying to get a lock.
+            // we need to know what the modify index is before we start, so that we can wait on a change if it the lock
+            // is not yet available.
+            try {
+                $modifyIndex = $this->kvService->get($this->key)->json()[0]['ModifyIndex'];
+            } catch (ClientException $exception) {
+                if (404 != $exception->getCode()) { // It is OK if it doesn't exist.
+                    throw $exception; // Everything else is a problem.
+                }
+            }
         }
 
-        register_shutdown_function(array($this, 'release'));
+        // Attempt to get the lock
+        if (false === ($this->lockAcquired = $this->kvService->put(
+                $this->key,
+                (string)$this->value,
+                ['acquire' => $this->getSessionId()]
+            )->json())
+        ) {
+            // We didn't get the lock this time, but we still have time to wait.
+            if (microtime(true) < $end_time) {
+                // Deal with the blocking call - this will block for up to $wait for the key to be modified.
+                $wait_whole_seconds = round($wait, 0, PHP_ROUND_HALF_UP);
+                try {
+                    $this->kvService->get($this->key, ['index' => $modifyIndex, 'wait' => "{$wait_whole_seconds}s"]);
+                } catch (ClientException $exception) {
+                    if (404 != $exception->getCode()) { // It is OK if the key has been deleted.
+                        throw $exception; // Everything else is a problem.
+                    }
+                }
+
+                return $this->lock($end_time - microtime(true)); // Try getting lock again with revised wait.
+            } else {
+                // We aren't waiting so immediately return false.
+                return false;
+            }
+        }
+
+        if (false === $this->shutdownRegistered) {
+            register_shutdown_function([$this, 'release']);
+            $this->shutdownRegistered = true;
+        }
 
         return true;
     }
 
-    public function release()
+    /**
+     * Release the lock. There are two possible ways of doing this. The default ephemeral mode will delete the
+     * key and destroy the session leaving no evidence of the lock.
+     * If the LockHandler is set to be non-ephemeral (permanent), the lock will be released and any provided value
+     * will be written to the key at the same time. If no value or null is provided the existing value
+     * will be used again.
+     *
+     * @param string $value
+     * @return void
+     */
+    public function release($value = null)
     {
-        $this->kv->delete($this->key);
-        $this->session->destroy($this->sessionId);
+        // For ephemeral locks the key and session will be deleted/destroyed at "release" time.
+        if (true === $this->isEphemeral() && true === $this->lockAcquired) {
+            $this->kvService->put($this->key, $value, ['release' => $this->getSessionId()]);
+            $this->kvService->delete($this->key);
+            $this->sessionService->destroy($this->sessionId);
+            $this->sessionId = null;
+            $this->lockAcquired = false;
+
+            return;
+        }
+
+        // For permanent locks the key/value remains in the KV store.
+        if (true === $this->lockAcquired) { // If we have the lock
+            if (null !== $value) { // Value is being changed on release.
+                $this->value = $value;
+            }
+            $this->kvService->put($this->key, $this->value, ['release' => $this->getSessionId()]);
+            $this->lockAcquired = false;
+        }
+
+        return;
     }
+
+    /**
+     * Upadte the locally held copy of the value. If the lock is currently held the KV store will also be updated.
+     *
+     * @param string $value
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
+        if ($this->lockAcquired) {
+            $this->lock(); // update the value in the kv store.
+        }
+    }
+
+    public function getSessionId()
+    {
+        if (!$this->sessionId) {
+            // For ephemeral locks we want the non-default behaviour of delete so that the lock is deleted on
+            // invalidation rather than just released.
+            // This matches the behaviour of calling an explicit release on an ephemeral lock.
+            $behaviour = 'release';
+            if ($this->isEphemeral()) {
+                $behaviour = 'delete';
+            }
+
+            // Start a session. This will stay with this lock handler so that the value can be updated without dropping and
+            // re-acquiring lock as per https://www.consul.io/docs/agent/http/kv.html#_acquire_lt_session_gt_
+            $session = $this->sessionService->create(
+                [
+                    'LockDelay' => $this->lockDelay,
+                    'TTL'       => $this->sessionTTL,
+                    'Behavior'  => $behaviour,
+                ]
+            )->json();
+            $this->sessionId = $session['ID'];
+        }
+
+        return $this->sessionId;
+
+    }
+
+    /**
+     * @param string $sessionTTL
+     */
+    public function setSessionTTL($sessionTTL)
+    {
+        $this->sessionTTL = $sessionTTL;
+    }
+
+    /**
+     * @param string $lockDelay
+     */
+    public function setLockDelay($lockDelay)
+    {
+        $this->lockDelay = $lockDelay;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEphemeral()
+    {
+        return $this->ephemeral;
+    }
+
+    /**
+     * @param bool $ephemeral
+     */
+    public function setEphemeral($ephemeral)
+    {
+        $this->ephemeral = $ephemeral;
+    }
+
 }

--- a/Consul/Services/KV.php
+++ b/Consul/Services/KV.php
@@ -17,7 +17,7 @@ class KV
     public function get($key, array $options = array())
     {
         $params = array(
-            'query' => OptionsResolver::resolve($options, array('dc', 'recurse', 'keys', 'separator', 'raw')),
+            'query' => OptionsResolver::resolve($options, array('dc', 'recurse', 'keys', 'separator', 'raw', 'index', 'wait')),
         );
 
         return $this->client->get('v1/kv/'.$key, $params);

--- a/Consul/Tests/Integration/Helper/LockHandlerTest.php
+++ b/Consul/Tests/Integration/Helper/LockHandlerTest.php
@@ -1,0 +1,356 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: steve.hall
+ * Date: 20/03/2017
+ * Time: 16:23
+ */
+
+namespace SensioLabs\Consul\Tests\Helper;
+
+use SensioLabs\Consul\Exception\ClientException;
+use SensioLabs\Consul\Exception\ConsulExceptionInterface;
+use SensioLabs\Consul\Helper\LockHandler;
+use SensioLabs\Consul\ServiceFactory;
+use SensioLabs\Consul\Services\KV;
+
+
+class LockHandlerTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @var ServiceFactory
+     */
+    private $sf;
+    /** @var  string */
+    private $prefix;
+
+    /** @var  KV */
+    private $kv;
+
+
+    /**
+     * Establish shared resources.
+     */
+    public function setUp()
+    {
+        $this->sf = new ServiceFactory(['base_url' => 'http://127.0.0.1:8500']);
+        /** @var KV kv */
+        $this->kv = $this->sf->get('kv');
+        // Start with a new prefix each time, so left overs from previous test runs don't pollute results
+        $this->prefix = 'testing_sensio_consul_lockhandler_'.microtime(true);
+
+    }
+
+    /**
+     * For tidiness sake remove the testing prefix.
+     */
+    protected function tearDown()
+    {
+        parent::tearDown();
+        try {
+            $this->kv->delete($this->prefix);
+        } catch (\Exception $e) {
+            // don't care if this failed - we tried to be tidy!
+        }
+    }
+
+    public function testPermanentExclusiveLock()
+    {
+
+        $lockHandler1 = new LockHandler(
+            $this->prefix,
+            'lock1 value',
+            $this->sf->get('session'),
+            $this->kv
+        );
+
+        $lockHandler1->setEphemeral(false);
+
+        $lockHandler2 = new LockHandler(
+            $this->prefix,
+            'lock2 value',
+            $this->sf->get('session'),
+            $this->kv
+        );
+        $lockHandler2->setEphemeral(false);
+
+        // Should be able to get one lock
+        static::assertTrue($lockHandler1->lock());
+
+        // And the value should have been set.
+        static::assertEquals('lock1 value', $this->kv->get($this->prefix, ['raw'=>true])->getBody());
+
+        // But cannot get a lock on the same key with a different session.
+        static::assertFalse($lockHandler2->lock());
+
+        // And the value should have stayed the sam.
+        static::assertEquals('lock1 value', $this->kv->get($this->prefix, ['raw'=>true])->getBody() );
+        static::assertNotEquals('lock2 value', $this->kv->get($this->prefix, ['raw'=>true])->getBody());
+
+        // Once the first lock is released
+        $lockHandler1->release();
+        // No change happens to the value
+        static::assertEquals('lock1 value', $this->kv->get($this->prefix, ['raw'=>true])->getBody());
+        static::assertNotEquals('lock2 value', $this->kv->get($this->prefix, ['raw'=>true])->getBody());
+
+        // Until we lock using the second handler
+        static::assertTrue($lockHandler2->lock());
+
+        // Now the value has changed.
+        static::assertNotEquals('lock1 value', $this->kv->get($this->prefix, ['raw'=>true])->getBody());
+        static::assertEquals('lock2 value', $this->kv->get($this->prefix, ['raw'=>true])->getBody());
+
+        // Lock 1 should not be able to release
+        $lockHandler1->release('lock 1 release value'); // No effect
+        static::assertNotEquals('lock 1 release value', $this->kv->get($this->prefix, ['raw'=>true])->getBody());
+        static::assertEquals('lock2 value', $this->kv->get($this->prefix, ['raw'=>true])->getBody());
+
+        // Lock 2 can release and changes the value on release.
+        $lockHandler2->release('lock 2 release value'); // Changes value and releases at the same time.
+        static::assertEquals('lock 2 release value', $this->kv->get($this->prefix, ['raw'=>true])->getBody());
+
+    }
+
+    public function testEphemeralExclusiveLock()
+    {
+
+        $lockHandler1 = new LockHandler(
+            $this->prefix,
+            'lock1 value',
+            $this->sf->get('session'),
+            $this->kv
+        );
+
+        $lockHandler2 = new LockHandler(
+            $this->prefix,
+            'lock2 value',
+            $this->sf->get('session'),
+            $this->kv
+        );
+
+        // Should be able to get one lock
+        static::assertTrue($lockHandler1->lock());
+
+        // And the value should have been set.
+        static::assertEquals('lock1 value', $this->kv->get($this->prefix, ['raw'=>true])->getBody());
+
+        // But cannot get a lock on the same key with a different session.
+        static::assertFalse($lockHandler2->lock());
+
+        // And the value should have stayed the sam.
+        static::assertEquals('lock1 value', $this->kv->get($this->prefix, ['raw'=>true])->getBody());
+        static::assertNotEquals('lock2 value', $this->kv->get($this->prefix, ['raw'=>true])->getBody());
+
+        // Once the first lock is released
+        $lockHandler1->release();
+
+        // the key should be gone which means we should get a ClientException with 404 code.
+        $this->expectException(ClientException::class);
+        $this->expectExceptionCode(404);
+        $this->kv->get($this->prefix);
+
+        // Until we lock using the second handler
+        static::assertTrue($lockHandler2->lock());
+
+        // Now the value exists again and is the right thing.
+        static::assertNotEquals('lock1 value', $this->kv->get($this->prefix, ['raw'=>true])->getBody());
+        static::assertEquals('lock2 value', $this->kv->get($this->prefix, ['raw'=>true])->getBody());
+
+
+    }
+
+    public function testEphemeralLockOwnership()
+    {
+        $lockHandler1 = new LockHandler(
+            $this->prefix,
+            'lock1 value',
+            $this->sf->get('session'),
+            $this->sf->get('kv')
+        );
+
+        $lockHandler2 = new LockHandler(
+            $this->prefix,
+            'lock2 value',
+            $this->sf->get('session'),
+            $this->sf->get('kv')
+        );
+
+        // Should be able to get one lock
+        static::assertTrue($lockHandler1->lock());
+        static::assertEquals('lock1 value', $this->kv->get($this->prefix, ['raw'=>true])->getBody());
+
+
+        // But not a second on the same key.
+        static::assertFalse($lockHandler2->lock());
+
+        // but should be fine to get the lock again with the existing handler
+        $lockHandler1->setValue('a new lock value');
+        static::assertTrue($lockHandler1->lock());
+        static::assertNotEquals('lock1 value', $this->kv->get($this->prefix, ['raw'=>true])->getBody());
+        static::assertEquals('a new lock value', $this->kv->get($this->prefix, ['raw'=>true])->getBody());
+
+        // And still only need to release once
+        $lockHandler1->release();
+
+        // After release the key / value is gone
+        $this->expectException(ClientException::class);
+        $this->expectExceptionCode(404);
+        $this->kv->get($this->prefix);
+
+        // A second thread can now acquire with new value.
+        static::assertTrue($lockHandler2->lock());
+        static::assertEquals('lock2 value', $this->kv->get($this->prefix, ['raw'=>true])->getBody());
+    }
+
+
+    public function testPermanentLockOwnership()
+    {
+        $lockHandler1 = new LockHandler(
+            $this->prefix,
+            'lock1 value',
+            $this->sf->get('session'),
+            $this->sf->get('kv')
+        );
+        $lockHandler1->setEphemeral(false);
+
+        $lockHandler2 = new LockHandler(
+            $this->prefix,
+            'lock2 value',
+            $this->sf->get('session'),
+            $this->sf->get('kv')
+        );
+        $lockHandler2->setEphemeral(false);
+
+        // Should be able to get one lock
+        static::assertTrue($lockHandler1->lock());
+        static::assertEquals('lock1 value', $this->kv->get($this->prefix, ['raw'=>true])->getBody());
+
+
+        // But not a second on the same key.
+        static::assertFalse($lockHandler2->lock());
+
+        // but should be fine to get the lock again with the existing handler
+        $lockHandler1->setValue('a new lock value');
+        static::assertTrue($lockHandler1->lock());
+        static::assertNotEquals('lock1 value', $this->kv->get($this->prefix, ['raw'=>true])->getBody());
+        static::assertEquals('a new lock value', $this->kv->get($this->prefix, ['raw'=>true])->getBody());
+
+        // And still only need to release once
+        $lockHandler1->release();
+
+        // After release the new value remains
+        static::assertEquals('a new lock value', $this->kv->get($this->prefix, ['raw'=>true])->getBody());
+
+        // A second thread can now acquire with new value.
+        static::assertTrue($lockHandler2->lock());
+        static::assertEquals('lock2 value', $this->kv->get($this->prefix, ['raw'=>true])->getBody());
+    }
+
+
+    /**
+     * We can't reliably multithread in this test, so blocking locks are tested by cheating slightly
+     * and setting a low TTL for the first lock obtained. After the TTL expires, Consul invalidates the session and
+     * the lock is released. At that point our blocking lock will be able to acquire.
+     * According to consul documentation on https://www.consul.io/docs/agent/http/session.html the minimum TTL is 10s
+     * and actual invalidation can take up to double this. So we will wait up to a maximum of 20s for the lock.
+     *
+     */
+    public function testBlockingPermanentLocks()
+    {
+        $lockHandler1 = new LockHandler(
+            $this->prefix,
+            'lock1 value',
+            $this->sf->get('session'),
+            $this->sf->get('kv')
+        );
+        $lockHandler1->setEphemeral(false);
+
+        $lockHandler2 = new LockHandler(
+            $this->prefix,
+            'lock2 value',
+            $this->sf->get('session'),
+            $this->sf->get('kv')
+        );
+        $lockHandler2->setEphemeral(false);
+
+
+        // Set the lowest TTL possible.
+        $lockHandler1->setSessionTTL('10s');
+        // Because we are relying upon session invalidation the LockDelay will kick in. Setting this to 0s prevents it
+        // from delaying our test.
+        $lockHandler1->setLockDelay('0s');
+
+        // Acquire the lock. In somewhere between 10s and 21s this should be invalidated and the lock released.
+        static::assertTrue($lockHandler1->lock(1));
+        static::assertEquals('lock1 value', $this->kv->get($this->prefix, ['raw'=>true])->getBody());
+
+        // First set a wait that isn't long enough to actually get the lock.
+        $start_time = microtime(true);
+        static::assertFalse($lockHandler2->lock(5));
+        $duration = microtime(true) - $start_time;
+        static::assertGreaterThanOrEqual(4, $duration);
+        static::assertLessThanOrEqual(6, $duration);
+        static::assertEquals('lock1 value', $this->kv->get($this->prefix, ['raw'=>true])->getBody());
+
+        // Now wait long enough for the session to invalidate
+        static::assertTrue($lockHandler2->lock(20));
+        $duration = microtime(true) - $start_time;
+        static::assertGreaterThanOrEqual(10, $duration);
+        static::assertLessThanOrEqual(21, $duration);
+        static::assertEquals('lock2 value', $this->kv->get($this->prefix, ['raw'=>true])->getBody());
+
+    }
+
+    public function testBlockingEphemeralLocks()
+    {
+        $lockHandler1 = new LockHandler(
+            $this->prefix,
+            'lock1 value',
+            $this->sf->get('session'),
+            $this->sf->get('kv')
+        );
+
+        $lockHandler2 = new LockHandler(
+            $this->prefix,
+            'lock2 value',
+            $this->sf->get('session'),
+            $this->sf->get('kv')
+        );
+
+
+        // Set the lowest TTL possible.
+        $lockHandler1->setSessionTTL('10s');
+        // Because we are relying upon session invalidation the LockDelay will kick in. Setting this to 0s prevents it
+        // from delaying our test.
+        $lockHandler1->setLockDelay('0s');
+
+        // Acquire the lock. In somewhere between 10s and 21s this should be invalidated and the lock released.
+        static::assertTrue($lockHandler1->lock(1));
+        static::assertEquals('lock1 value', $this->kv->get($this->prefix, ['raw'=>true])->getBody());
+
+        // First set a wait that isn't long enough to actually get the lock.
+        $start_time = microtime(true);
+        static::assertFalse($lockHandler2->lock(5));
+        $duration = microtime(true) - $start_time;
+        static::assertGreaterThanOrEqual(4, $duration);
+        static::assertLessThanOrEqual(6, $duration);
+        static::assertEquals('lock1 value', $this->kv->get($this->prefix, ['raw'=>true])->getBody());
+
+        // Now wait long enough for the session to invalidate
+        static::assertTrue($lockHandler2->lock(20));
+        $duration = microtime(true) - $start_time;
+        static::assertGreaterThanOrEqual(10, $duration);
+        static::assertLessThanOrEqual(21, $duration);
+        static::assertEquals('lock2 value', $this->kv->get($this->prefix, ['raw'=>true])->getBody());
+
+        $lockHandler2->release();
+        // After release the key / value is gone
+        $this->expectException(ClientException::class);
+        $this->expectExceptionCode(404);
+        $this->kv->get($this->prefix);
+
+    }
+
+
+}


### PR DESCRIPTION
The LockHandler helper has been modified to take advantage of blocking `GET` to wait on the release of a lock and attempt to acquire it in the current thread. Also added ability to have permanent keys used as lock as well as the current ephemeral ones. 

Current behaviour is hopefully retained with no BC breaks. Tests have been written to cover the old behaviour and the new. 

